### PR TITLE
Changed recipes order, so directories created before packages installation.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,9 +1,9 @@
-include_recipe 'rails-stack::packages'
-
 # User deployer
 include_recipe 'rails-stack::user'
 include_recipe 'rails-stack::sudoers'
 include_recipe 'rails-stack::lib_directory'
+
+include_recipe 'rails-stack::packages'
 
 include_recipe 'rails-stack::ruby'
 


### PR DESCRIPTION
The nodejs installation fails because the directories are not created and installer cannot change the tmppath to required.
