### PR TITLE
Added monit config for monitoring drives space

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,8 @@ default['rails-stack']['deployer']         = 'deployer'
 default['rails-stack']['applications']     = Array.new
 default['rails-stack']['packages']         = Array.new
 default['rails-stack']['packages']         = Array.new
-default['rails-stack']['monitor_services'] = {nginx: true, memcached: true, postgresql: true}
+default['rails-stack']['monitor_services'] = {nginx: true, memcached: true, postgresql: true, drives_space: true}
+default['rails-stack']['monit']['drives'] = { rootfs: { 'path' => '/', 'space_limit' => '80%' } }
 
 default[:ruby][:version] = '2.1.0'
 

--- a/templates/default/monit/drives_space.conf.erb
+++ b/templates/default/monit/drives_space.conf.erb
@@ -1,0 +1,6 @@
+<% node['rails-stack']['monit']['drives'].each do |name, params| %>
+  <% path = params['path'] %>
+  <% space_limit = params['space_limit'] || '80%' %>
+  CHECK filesystem <%= name %> WITH PATH <%= path %>
+    if SPACE usage > <%= space_limit %> then alert
+<% end %>


### PR DESCRIPTION
Added new service to 'monitor_services' with the name drives_space and created template for that service. So now usage space for multiple drives can be monitored using monit.

Syntax:

``` json
{
    "monit": {
      "drives": {
        "rootfs": {
          "path": "/"
        },

        "var": {
          "path": "/var",
          "space_limit": "30%"
        }
      }
    }
}
```
