### PR TITLE
Added monit raw configs support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,8 @@ default['rails-stack']['applications']     = Array.new
 default['rails-stack']['packages']         = Array.new
 default['rails-stack']['packages']         = Array.new
 default['rails-stack']['monitor_services'] = {nginx: true, memcached: true, postgresql: true, drives_space: true}
-default['rails-stack']['monit']['drives'] = { rootfs: { 'path' => '/', 'space_limit' => '80%' } }
+default['rails-stack']['monit']['drives'] = { rootfs: { path: '/', space_limit: '80%' } }
+default['rails-stack']['monit']['raw_configs'] = { }
 
 default[:ruby][:version] = '2.1.0'
 

--- a/recipes/monit.rb
+++ b/recipes/monit.rb
@@ -12,8 +12,20 @@ if node['platform_family'] == 'rhel'
 end
 
 node['rails-stack']['monitor_services'].each do |service_name, enabled|
+  monit_action = enabled ? :enable : :disable
   monitrc service_name do
+    action monit_action
     template_source "monit/#{service_name}.conf.erb"
     template_cookbook 'rails-stack'
+  end
+end
+
+node['rails-stack']['monit']['raw_configs'].each do |service_name, raw_config|
+  monit_action = (!raw_config or raw_config.empty?) ? :disable : :enable
+  monitrc service_name do
+    action monit_action
+    template_source 'monit/raw_configs.conf.erb'
+    template_cookbook 'rails-stack'
+    variables config_source: raw_config
   end
 end

--- a/templates/default/monit/raw_configs.conf.erb
+++ b/templates/default/monit/raw_configs.conf.erb
@@ -1,0 +1,1 @@
+<%= @config_source %>


### PR DESCRIPTION
Added ability to write raw monit configs in node's config files and roles.
The syntax is

``` json
{
  "rails-stack": {
    "monit": {
      "raw_configs": {
        "config_name": "raw\nconfig\ncode"
      }
    }
  }
}
```
